### PR TITLE
ダッシュボード画面において、会社に紐づく情報の取得、ログインしているユーザー名の表示を可能にしました。

### DIFF
--- a/api/app/controllers/authentication_controller.rb
+++ b/api/app/controllers/authentication_controller.rb
@@ -13,6 +13,11 @@ class AuthenticationController < ApplicationController
     end
   end
 
+  def destroy
+    session[:user_id] = nil
+    render json: { logged_out: true }, status: :ok
+  end
+
   private
 end
   

--- a/api/app/controllers/authentication_controller.rb
+++ b/api/app/controllers/authentication_controller.rb
@@ -1,31 +1,18 @@
 class AuthenticationController < ApplicationController
-    # skip_before_action :verify_authenticity_token
-  
-    def login
-      user = User.find_by(email: params[:email],password: params[:password])
-      logger.debug "Loaded user: #{user.inspect}"
-  
-      if user
-        # 認証に成功した場合の処理（例：トークンの発行）
-        token = SecureRandom.hex(64)
-        logger.debug "Loaded token: #{token.inspect}"
-        render json: { token: token }, status: :ok
-      else
-        # 認証に失敗した場合の処理
-        render json: { error: 'Invalid credentials' }, status: :unauthorized
-      end
-
-      def show
-        @user = User.find(params[:id])
-        logger.debug "Loaded user: #{@user.inspect}"
-      end
-    end
-  
-    private
-  
-    def generate_token(user)
-      # JWTトークンを生成するロジック（JWT gemを使用する場合）
-      # JWT.encode(payload, secret, 'HS256')
+  def login
+    user = User.find_by(email: params[:email])
+    # if 
+    if user && user.authenticate(params[:password])
+      # 認証に成功した場合の処理（例：トークンの発行）
+      token = SecureRandom.hex(64)
+      user.update(token: token)
+      render json: { token: token, name: user.name }, status: :ok
+    else
+      # 認証に失敗した場合の処理
+      render json: { error: 'Invalid credentials' }, status: :unauthorized
     end
   end
+
+  private
+end
   

--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -7,16 +7,6 @@ class UsersController < ApplicationController
     render json: @users
   end
 
-  # GET /users/1
-  def show
-    user = User.find(params[:id])
-    render json: user
-  end
-
-  def get_login_user_name
-    render json: current_user
-  end
-
   # POST /users
   def create
     @users = User.new(user_params)
@@ -28,27 +18,24 @@ class UsersController < ApplicationController
     end
   end
 
-  def search
-    user = User.find_by(email: params[:email])
+  def show
+    user = User.find(session[:user_id])
     if user
-      render json: user
+      render json: { name: user.name, email: user.email }, status: :ok
     else
-      render json: { error: "ユーザーが見つかりませんでした" }, status: :not_found
+      render json: { error: 'ユーザーが見つかりません' }, status: :not_found
     end
-  rescue StandardError => e
-    render json: { error: e.message }, status: :internal_server_error
   end
 
   private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_user
-      @user = User.find(params[:email])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_user
+    @user = User.find(params[:email])
+  end
 
-    # Only allow a trusted parameter "white list" through.
-    def user_params
-      params.require(:user).permit(:name, :email, :password)
-    end
-
+  # Only allow a trusted parameter "white list" through.
+  def user_params
+    params.permit(:name, :email, :password)
+  end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+    has_secure_password
 end

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
   end
 end

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
+      expose: ['Authorization'],
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
       credentials: true
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
   resources :users, only: [:index, :show, :create, :update]
-  get 'user', to: 'users#show'
-  get '/current_user', to: 'users#current'
+  get 'users', to: 'users#show'
   post '/login', to: 'authentication#login'
-  get '/dashbord', to: 'dashbords#index'
+  get '/dashboard', to: 'dashboards#index'
 
   resources :companies, only: [:index, :create]
   post '/companies', to: 'companies#create_with_key_person'

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,5 +13,7 @@ Rails.application.routes.draw do
   resources :attack_logs, only: [:index, :show, :create, :update, :destroy]
 
   resources :todos, except: [:new, :edit]
+
+  delete '/logout', to: 'authentication#destroy'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/api/db/migrate/20240225030953_add_token_to_users.rb
+++ b/api/db/migrate/20240225030953_add_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddTokenToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :token, :string
+    add_index :users, :token, unique: true
+  end
+end

--- a/api/db/migrate/20240226100316_remove_password_add_password_digest_to_users.rb
+++ b/api/db/migrate/20240226100316_remove_password_add_password_digest_to_users.rb
@@ -1,0 +1,6 @@
+class RemovePasswordAddPasswordDigestToUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :password, :string
+    add_column :users, :password_digest, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_24_110340) do
+ActiveRecord::Schema.define(version: 2024_02_26_100316) do
 
   create_table "attack_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "calling_start", comment: "架電開始時間"
@@ -56,9 +56,11 @@ ActiveRecord::Schema.define(version: 2024_02_24_110340) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
-    t.string "password"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "token"
+    t.string "password_digest"
+    t.index ["token"], name: "index_users_on_token", unique: true
   end
 
   add_foreign_key "attack_logs", "companies"

--- a/front/components/AttackLog/AttackLogCallResult.tsx
+++ b/front/components/AttackLog/AttackLogCallResult.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useState, ChangeEvent } from 'react';
 import { useRouter } from 'next/router';
+import { FilterCallingResult } from '../FilterComponents/FilterCallingResult' 
 import { Textarea, Input, FormControl, FormLabel, FormErrorMessage } from '@chakra-ui/react'
 import { AttackLog, Company } from '@/types/interface';
 
@@ -88,7 +89,7 @@ export const AttackLogCallResult  = ({ onInputChange, errors  }) => {
         setCallingStart(e.target.value);
         onInputChange('callingStart', e.target.value);
       };
-      const handleCallResultInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const handleCallResultChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         setCallResult(e.target.value);
         onInputChange('callResult', e.target.value);
       };
@@ -111,7 +112,10 @@ export const AttackLogCallResult  = ({ onInputChange, errors  }) => {
             <div className='w-1/2 mx-9 my-5'>
                 <div className='flex mx-auto'>
                     <div>
-                        <InputField label="架電結果" name="call_result" id="call_result" errorMessage={errors.callResult} value={callResult} onChange={handleCallResultInputChange}/>
+                      <label className="text-sm font-semibold leading-6 text-sky-400">架電結果</label>
+                      <div className="w-64 mt-2 -ml-5 mr-5">
+                        <FilterCallingResult onCallingResultChange={handleCallResultChange}/>
+                      </div>
                     </div>
                     <div className='ml-12'>
                       <label className="text-sm font-semibold leading-6 text-sky-400">架電開始時間</label>

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@chakra-ui/react';
 import { FilterCallingResult } from '../FilterComponents/FilterCallingResult';
 import { FilterCompany } from '../FilterComponents/FilterCompany';
@@ -8,10 +8,9 @@ import { FilterIndustryCompany } from '../FilterComponents/FilterCompanyIndustry
 import { FilterSalesman } from '../FilterComponents/FilterSalesman';
 import { FilterNextCallingDay } from '../FilterComponents/FilterNextCallingDay'
 import { useCompanyAndKeyPersonsData } from './useSWRCompanyList';
-import { Company, ExtendedCompany } from '../../types/interface';
+import { Company, ExtendedCompany, ExtendedCompanyWithKeyPerson } from '../../types/interface';
 
   export const CompanyList = () => {
-    // const [companies, setCompanies] = useState([]);
     const [selectedOption, setSelectedOption] = useState('');
     const [filterCompanyName, setFilterCompanyName] = useState('');
     const [filterCompanyNumber, setFilterCompanyNumber] = useState('');
@@ -23,7 +22,7 @@ import { Company, ExtendedCompany } from '../../types/interface';
     if (isLoading) return <div>Loading...</div>;
     if (isError) return <div>Error loading data</div>;
 
-    const handleSelectChange = (event) => {
+    const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedOption(event.target.value);
     };
     const handleCompanyChange = (companyName: string) => {
@@ -95,8 +94,8 @@ import { Company, ExtendedCompany } from '../../types/interface';
                 </tr>
               </thead>
               <tbody  className='border-solid border-2'>
-                {filteredCompanies.map((company, index) => {
-                   const companyIndustry = company.industry.length > 10 
+                {filteredCompanies.map((company: ExtendedCompanyWithKeyPerson, index: number) => {
+                   const companyIndustry = company.industry?.length > 10 
                    ? `${company.industry.substring(0, 10)}...` 
                    : company.industry;
                   return (

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -6,8 +6,9 @@ import { FilterCompany } from '../FilterComponents/FilterCompany';
 import { FilterCompanyNumber } from '../FilterComponents/FilterCompanyNumber';
 import { FilterIndustryCompany } from '../FilterComponents/FilterCompanyIndustry';
 import { FilterSalesman } from '../FilterComponents/FilterSalesman';
+import { FilterNextCallingDay } from '../FilterComponents/FilterNextCallingDay'
 import { useCompanyAndKeyPersonsData } from './useSWRCompanyList';
-import { Company } from '../../types/interface';
+import { Company, ExtendedCompany } from '../../types/interface';
 
   export const CompanyList = () => {
     // const [companies, setCompanies] = useState([]);
@@ -15,7 +16,8 @@ import { Company } from '../../types/interface';
     const [filterCompanyName, setFilterCompanyName] = useState('');
     const [filterCompanyNumber, setFilterCompanyNumber] = useState('');
     const [filterCompanyIndustry, setFilterCompanyIndustry] = useState('');
-    const [filterCompanySalesman, setFilterCompanySalesman] = useState('');
+    const [filterSalesman, setFilterSalesman] = useState('');
+    const [filterNextCallingDay, setNextCallingDay ] = useState('');
     const { mergedData, isLoading, isError } = useCompanyAndKeyPersonsData();
     
     if (isLoading) return <div>Loading...</div>;
@@ -33,11 +35,17 @@ import { Company } from '../../types/interface';
     const handleIndustryChange = (companyIndustry: string) => {
       setFilterCompanyIndustry(companyIndustry);
     };
-    const handleSalesmanChange = (companySalesman: string) => {
-      setFilterCompanySalesman(companySalesman);
+    const handleSalesmanChange = (Salesman: string) => {
+      setFilterSalesman(Salesman);
     };
+    const handleNextCallingDayChange = (NextCallingDay: string) => {
+      setNextCallingDay(NextCallingDay);
+    }
 
     const filteredCompanies = mergedData
+    .filter((company: ExtendedCompany) =>
+    selectedOption === '' || company.latestCallResult!.toLowerCase().includes(selectedOption.toLowerCase()) 
+    )
     .filter((company: Company) =>
       filterCompanyName === '' || company.company_name.toLowerCase().includes(filterCompanyName.toLowerCase()) 
     )
@@ -48,19 +56,14 @@ import { Company } from '../../types/interface';
     .filter((company: Company) =>
       filterCompanyIndustry === '' || (company.industry && company.industry.toLowerCase().includes(filterCompanyIndustry.toLowerCase())) 
     )
-    .filter((company: Company) =>
-      filterCompanySalesman === '' || company.keyPerson.name.toLowerCase().includes(filterCompanySalesman.toLowerCase()) 
+    .filter((company: ExtendedCompany) =>
+      filterSalesman === '' || company.latestSalesman!.toLowerCase().includes(filterSalesman.toLowerCase()) 
+    )
+    .filter((company: ExtendedCompany) =>
+    filterNextCallingDay === '' || company.nextCallDay!.toLowerCase().includes(filterNextCallingDay.toLowerCase()) 
     );
-    // 現在は試しでkeyPersonを表示、品等は営業担当に変更する
-
-
-    // アタックログから情報を取得
-    // const filteredCallingResult = selectedOption
-    // ? companies.filter(company => attacklog.--- === selectedOption) // 仮にアポイント結果をappointmentResultプロパティと仮定
-    // : companies;
-  
+    
     return (
-      // console.log(filteredCompanies),
     <div>
         <div className="flex h-[70px] bg-cyan-400 items-center justify-around">
           <div className='flex'>
@@ -69,7 +72,8 @@ import { Company } from '../../types/interface';
             <FilterCompanyNumber onCompanyNumberChange={handleInputNumberChange}/>
             <FilterIndustryCompany onCompanyIndustryChange={handleIndustryChange}/>
             <FilterSalesman onCompanySalesmanChange={handleSalesmanChange}/>
-            <Button colorScheme='blue' mx='5' type="submit" px="90">
+            <FilterNextCallingDay onNextCallingDayChange={handleNextCallingDayChange}/>
+            <Button colorScheme='blue' mx='5' type="submit" px="5">
               <Link href={'/company-resister'}>企業登録フォームへ</Link>
             </Button>
           </div>
@@ -98,15 +102,15 @@ import { Company } from '../../types/interface';
                   return (
                     <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-100'}>
                       <td className='border-2'>{company.address}</td>
-                      <td className='border-2'>アポイント{index + 1}</td>
-                      <td className='border-2'>担当者 {index + 1}</td>
-                      <td className='border-2'>予定日 {index + 1}</td>
+                      <td className='border-2'>{company.latestCallResult}</td>
+                      <td className='border-2'>{company.latestSalesman}</td>
+                      <td className='border-2'>{company.nextCallDay}</td>
                       <td className='border-2'><Link href={`/attacklog?company=${company.id}`}>{company.company_name}</Link></td>
                       <td className='border-2'>{company.telephone_number}</td>
                       <td className='border-2'>{companyIndustry}</td>
-                      <td className='border-2'>{company.keyPerson? company.keyPerson.name : 'N/A'}</td>
-                      <td className='border-2'>{company.keyPerson? company.keyPerson.department : 'N/A'}</td>
-                      <td className='border-2'>特記事項 {index + 1}</td>
+                      <td className='border-2'>{company.keyPerson? company.keyPerson.name : ''}</td>
+                      <td className='border-2'>{company.keyPerson? company.keyPerson.department : ''}</td>
+                      <td className='border-2'>{company.keyPerson? company.keyPerson.note : ''}</td>
                     </tr>
                   );
                   })}

--- a/front/components/CompanyList/useSWRCompanyList.tsx
+++ b/front/components/CompanyList/useSWRCompanyList.tsx
@@ -1,4 +1,4 @@
-import { Company, KeyPerson } from '@/types/interface';
+import { Company, KeyPerson, AttackLog } from '@/types/interface';
 import useSWR from 'swr';
 
 const fetcher = async (url: string) => {
@@ -12,20 +12,44 @@ const fetcher = async (url: string) => {
 export const useCompanyAndKeyPersonsData = () => {
   const { data: companiesData, error: companiesError } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/companies`, fetcher);
   const { data: keyPersonsData, error: keyPersonsError } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/key_persons`, fetcher);
+  const { data: attackLogsData, error: attackLogsError } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/attack_logs`, fetcher);
 
-  if (companiesError || keyPersonsError) {
-    console.error('Error fetching data:', companiesError || keyPersonsError);
+  if (companiesError || keyPersonsError || attackLogsError) {
+    console.error('Error fetching data:', companiesError || keyPersonsError || attackLogsError);
     return { mergedData: null, isLoading: false, isError: true };
   }
 
-  if (!companiesData || !keyPersonsData) {
+  if (!companiesData || !keyPersonsData || !attackLogsData) {
     return { mergedData: null, isLoading: true, isError: false };
   }
+  const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false // 24時間表示
+    };
+    // ロケールを日本に設定しても良いですが、ブラウザのデフォルト設定を使用しても構いません
+    return new Intl.DateTimeFormat('ja-JP', options).format(date).replace(/\//g, '/');
+  }
 
-  const mergedData = companiesData.map((company: Company) => ({
-    ...company,
-    keyPerson: keyPersonsData.find((kp: KeyPerson) => kp.company_id === company.id)
-  }));
-
+  const mergedData = companiesData.map((company: Company) => {
+    const companyAttackLogs = attackLogsData.filter((log: AttackLog) => log.company_id === company.id);
+    // 最新のログを取得するために、日付でソート（仮にcreated_atを使用）
+    const latestLog = companyAttackLogs.sort((a: AttackLog, b: AttackLog) => 
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )[0]; // 最新のものが先頭に来るようにして、先頭の要素を取得
+  
+    return {
+      ...company,
+      keyPerson: keyPersonsData.find((kp: KeyPerson) => kp.company_id === company.id),
+      latestCallResult: latestLog ? latestLog.call_result : '', 
+      latestSalesman: latestLog ? latestLog.salesman : '', 
+      nextCallDay: latestLog ? formatDate(latestLog.next_call_day) : '',
+    };
+  });
   return { mergedData, isLoading: false, isError: false };
-};
+}

--- a/front/components/FilterComponents/FilterCallingResult.tsx
+++ b/front/components/FilterComponents/FilterCallingResult.tsx
@@ -7,7 +7,7 @@ interface FilterCallingResult {
 
 export const FilterCallingResult: React.FC<FilterCallingResult> = ({ onCallingResultChange }) => {
   return (
-        <Select placeholder='架電結果' bg='Cyan 50' ml='5' onChange={onCallingResultChange}>
+        <Select placeholder='架電結果' bg='Cyan 50' ml='5' w={130} onChange={onCallingResultChange}>
             <option value='アポイント'>アポイント</option>
             <option value='コンタクト'>コンタクト</option>
             <option value='資料送付'>資料送付</option>

--- a/front/components/FilterComponents/FilterCallingResult.tsx
+++ b/front/components/FilterComponents/FilterCallingResult.tsx
@@ -16,6 +16,7 @@ export const FilterCallingResult: React.FC<FilterCallingResult> = ({ onCallingRe
             <option value='不在'>不在</option>
             <option value='不通'>不通</option>
             <option value='現アナ'>現アナ</option>
+            <option value='テスト'>テスト</option>
         </Select>
   );
 }

--- a/front/components/FilterComponents/FilterNextCallingDay.tsx
+++ b/front/components/FilterComponents/FilterNextCallingDay.tsx
@@ -1,0 +1,29 @@
+import { Stack, Input } from '@chakra-ui/react';
+import React from 'react';
+import { useState } from 'react';
+
+interface FilterCompanyProps {
+    onNextCallingDayChange: (companyIndustry: string) => void;
+  }
+  
+  export const FilterNextCallingDay: React.FC<FilterCompanyProps> = ({ onNextCallingDayChange }) => {
+    const [NextCallingDay, setNextCallingDay] = useState('');
+  
+    const handleNextCallingDayChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setNextCallingDay(event.target.value);
+      onNextCallingDayChange(event.target.value);
+    };
+
+  return (
+    <Stack ml='5'>
+      <Input
+        placeholder='次回架電日'
+        size='md'
+        bg='Cyan 50'
+        w='120px'
+        value={NextCallingDay}
+        onChange={handleNextCallingDayChange}
+      />
+    </Stack>
+  );
+}

--- a/front/components/Header.tsx
+++ b/front/components/Header.tsx
@@ -1,45 +1,33 @@
+import React, { useEffect, useState } from 'react';
 import { Flex, Box, Spacer } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
-import useSWR from 'swr';
 
 export const Header = () => {
+  const [userName, setUserName] = useState('');
+  const [error, setError] = useState('');
 
-    const fetcher = (url: string) => axios.get(url).then(res => res.data);
-    const { data, error } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/users`, fetcher);
-    if (error) {
-      return <div>ユーザーデータの取得に失敗しました。</div>;
+  useEffect(() => {
+    // ローカルストレージからユーザー名を取得
+    const name = localStorage.getItem('userName');
+    if (name) {
+      setUserName(name);
+    } else {
+      setError('ユーザーデータの取得に失敗しました。');
     }
-
-    if (!data) {
-      return <div>ローディング中...</div>;
-    }
-
-    const userName = data.name;
-
-    // useEffect(() => {
-    //     axios.get(`${process.env.NEXT_PUBLIC_API_URL}/users`
-    //     )
-    //     .then(response => {
-    //       setUserName(response.data[0].name);
-    //     })
-    //     .catch(error => console.error('Error fetching user data:', error));
-    // }, []);
+  }, []);
 
   return (
     <Flex
       height="70px" 
       alignItems="center" 
-      bgGradient="linear(to-r, blue.700, blue.500)" 
+      bgGradient="linear(to-r, blue.700, blue.500)"
     >
       <Box color="white" fontSize="xl" pl={20}>
-        Header
+        Calling
       </Box>
-      <Spacer /> 
+      <Spacer />
       <Box color="white" fontSize="xl" pr={20}>
-        {userName}
+        {userName ? userName : 'ローディング中...'}
       </Box>
     </Flex>
   );
-}
-
+};

--- a/front/components/Header.tsx
+++ b/front/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Flex, Box, Spacer } from '@chakra-ui/react';
+import { LogoutButton } from '../components/Logout';
 
 export const Header = () => {
   const [userName, setUserName] = useState('');
@@ -28,6 +29,7 @@ export const Header = () => {
       <Box color="white" fontSize="xl" pr={20}>
         {userName ? userName : 'ローディング中...'}
       </Box>
+      <LogoutButton/>
     </Flex>
   );
 };

--- a/front/components/LoginInfo.tsx
+++ b/front/components/LoginInfo.tsx
@@ -13,6 +13,8 @@ import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { LoginForm, ErrorResponse } from "@/types/interface";
+import { AxiosError, AxiosResponse } from 'axios';
 
 export const LoginInfo = () => {
   const [formErrors, setFormErrors] = useState({});
@@ -33,22 +35,30 @@ export const LoginInfo = () => {
     resolver: yupResolver(schema),
   });
 
-  const onSubmit = async (data) => {
+  const onSubmit = async (data: LoginForm) => {
     try {
       console.log(data); 
-      const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
+      // 最初の {name: string} は送信するデータの型を示し、AxiosResponse<{name: string}> はレスポンスの型
+      const response = await axios.post<{name: string}, AxiosResponse<{name: string}>>(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
         email: data.email,
         password: data.password,
       });
-      console.log(response.data); 
-      // 認証成功のレスポンスを確認
-      if (response.data.token) {
-        router.push('/dashbord');
+      const { name } = response.data;
+      // ローカルストレージにユーザー名を保存
+      localStorage.setItem('userName', name);
+      router.push('/dashboard');
+    } catch (error: unknown) {
+      // unknown型のエラーに対して、それが実際にはAxiosError型であり、
+      // 更にそのエラーレスポンスがErrorResponse型であることをTypeScriptに教える
+      // これにより、error.responseが存在することが保証される。
+      if (axios.isAxiosError(error)) {
+        const serverError = error as AxiosError<ErrorResponse>;
+        if (serverError && serverError.response) {
+          setFormErrors({ server: serverError.response.data.message });
+        }
       } else {
-        setFormErrors({ server: "認証に失敗しました。" });
+        console.error('予期せぬエラーが発生', error);
       }
-    } catch (error) {
-      setFormErrors({ server: error.response.data.message });
     }
   };
 

--- a/front/components/LoginInfo.tsx
+++ b/front/components/LoginInfo.tsx
@@ -37,7 +37,6 @@ export const LoginInfo = () => {
 
   const onSubmit = async (data: LoginForm) => {
     try {
-      console.log(data); 
       // 最初の {name: string} は送信するデータの型を示し、AxiosResponse<{name: string}> はレスポンスの型
       const response = await axios.post<{name: string}, AxiosResponse<{name: string}>>(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
         email: data.email,

--- a/front/components/Logout.tsx
+++ b/front/components/Logout.tsx
@@ -6,7 +6,7 @@ export const LogoutButton = () => {
   
   const Logout = async () => {
   try {
-    const response = await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/logout`, {
+    await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/logout`, {
       withCredentials: true // セッションCookieをリクエストに含める
     });
     localStorage.removeItem('userName');

--- a/front/components/Logout.tsx
+++ b/front/components/Logout.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+import axios from 'axios';
+
+export const LogoutButton = () => {
+  const router = useRouter();
+  
+  const Logout = async () => {
+  try {
+    const response = await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/logout`, {
+      withCredentials: true // セッションCookieをリクエストに含める
+    });
+    localStorage.removeItem('userName');
+    router.push('/login'); 
+  } catch (error) {
+    alert("ログアウトに失敗しました。");
+  }};
+
+  return (
+    <div className='text-white pr-4 text-xl'>
+      <button onClick={Logout}>ログアウト</button>
+    </div>
+  );
+};

--- a/front/pages/company-resister.tsx
+++ b/front/pages/company-resister.tsx
@@ -64,7 +64,7 @@ import { ImportButton } from '../components/Import';
           }
         });
         if (response.status === 200) {
-          router.push('/dashbord');
+          router.push('/dashboard');
         } 
       } catch (validationError) {
         if (validationError instanceof yup.ValidationError) {
@@ -137,7 +137,7 @@ import { ImportButton } from '../components/Import';
 
           <Button mt={4} colorScheme='blue' type="submit">登録</Button>
           <Button mt={4} ml={6} colorScheme='blue' type="submit">
-            <Link href={'/dashbord'}>ダッシュボード</Link>
+            <Link href={'/dashboard'}>ダッシュボード</Link>
           </Button>
         </form>
           <ImportButton/>

--- a/front/pages/dashboard.tsx
+++ b/front/pages/dashboard.tsx
@@ -1,7 +1,7 @@
 import { Header } from "../components/Header";
 import { CompanyList } from "../components/CompanyList/CompanyList";
 
-export default function Dashbord(){
+export default function Dashboard(){
     return(
         <div>
             <Header/>

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -50,7 +50,7 @@ export const User = ({session, handleSignOut}) => {
       </div>
 
       <div className='flex justify-center'>
-        <Link href={'/dashbord'} className="mt-5 px-10 py-1 rounded-sm bg-indigo-500 text-gray-50">dashbord</Link>
+        <Link href={'/dashboard'} className="mt-5 px-10 py-1 rounded-sm bg-indigo-500 text-gray-50">dashboard</Link>
       </div>
     </main>
   )

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -28,72 +28,87 @@ export interface CompanyResisterFormState {
 
 // CompanyRegister.tsxで使用
 export interface CompanyResisterFormErrors {
-	[key: string]: string;
+  [key: string]: string;
 }
 
 export interface AttackLogFormErrors {
-	[key: string]: string;
+  [key: string]: string;
 }
 
 export interface AttackLogFormState {
-	companyId: string | null;
-	companyName: string | null;
-	address: string | null;
-	telephoneNumber: string | null;
-	companyWebsite: string | null;
-	department: string | null;
-	post: string | null;
-	name: string | null;
-	number: string | null;
-	email: string | null;
-	note: string | null;
-	callingStart: string | null;
-	callResult: string | null;
-	nextCallDay: string | null;
-	salesman: string | null;
-	callContent: string | null;
+  companyId: string | null;
+  companyName: string | null;
+  address: string | null;
+  telephoneNumber: string | null;
+  companyWebsite: string | null;
+  department: string | null;
+  post: string | null;
+  name: string | null;
+  number: string | null;
+  email: string | null;
+  note: string | null;
+  callingStart: string | null;
+  callResult: string | null;
+  nextCallDay: string | null;
+  salesman: string | null;
+  callContent: string | null;
 }
 
 export interface Company {
-	id?: number;
-	company_name: string;
-	industry: string;
-	address: string;
-	telephone_number: string;
-	company_website: string;
+  id?: number;
+  company_name: string;
+  industry: string;
+  address: string;
+  telephone_number: string;
+  company_website: string;
 }
 
 export interface KeyPerson {
-	company_id?: bigint;
-	department: string;
-	post: string;
-	name: string;
-	email: string;
-	telephone_number: string;
-	note: string;
+  company_id?: bigint;
+  department: string;
+  post: string;
+  name: string;
+  email: string;
+  telephone_number: string;
+  note: string;
 }
 
 export interface AttackLog {
-	company_id?: bigint;
-	calling_day: string;
-	calling_start: string;
-	call_result: string;
-	call_content: string;
-	next_call_day: string;
-	salesman: string;
-	created_at: string;
-	updated_at: string;
+  company_id?: bigint;
+  calling_day: string;
+  calling_start: string;
+  call_result: string;
+  call_content: string;
+  next_call_day: string;
+  salesman: string;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface ExtendedCompany extends Company {
-	latestSalesman?: string; // 最新の営業担当者名
-	latestCallResult?: string; // 最新の架電結果
-	nextCallDay?: string; // 次回予定日
+  latestSalesman?: string; // 最新の営業担当者名
+  latestCallResult?: string; // 最新の架電結果
+  nextCallDay?: string; // 次回予定日
 }
 
 export interface ExtendedCompanyWithKeyPerson extends Company {
-	latestSalesman?: string;
-	latestCallResult?: string;
-	nextCallDay?: string;
-	keyPerson?: KeyPerson; // KeyPerson をネスト
+  latestSalesman?: string;
+  latestCallResult?: string;
+  nextCallDay?: string;
+  keyPerson?: KeyPerson; // KeyPerson をネスト
+}
+
+export interface LoginForm {
+  email: string;
+  password: string;
+}
+
+export interface RegisterForm {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface ErrorResponse {
+  message: string;
 }

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -89,4 +89,11 @@ export interface ExtendedCompany extends Company {
 	latestSalesman?: string; // 最新の営業担当者名
 	latestCallResult?: string; // 最新の架電結果
 	nextCallDay?: string; // 次回予定日
-  }
+}
+
+export interface ExtendedCompanyWithKeyPerson extends Company {
+	latestSalesman?: string;
+	latestCallResult?: string;
+	nextCallDay?: string;
+	keyPerson?: KeyPerson; // KeyPerson をネスト
+}

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -81,4 +81,12 @@ export interface AttackLog {
 	call_content: string;
 	next_call_day: string;
 	salesman: string;
+	created_at: string;
+	updated_at: string;
 }
+
+export interface ExtendedCompany extends Company {
+	latestSalesman?: string; // 最新の営業担当者名
+	latestCallResult?: string; // 最新の架電結果
+	nextCallDay?: string; // 次回予定日
+  }


### PR DESCRIPTION
## やったこと
* ダッシュボード画面において、会社に紐づく情報の取得、ログインしているユーザー名の表示、フィルター検索を可能にしました。
ログアウトボタンを実装しました。
* アタックログの架電結果をプルダウン形式に変更
## やらないこと
* 「無し」
## 課題
* 現状ありません。
## できるようになること（ユーザ目線）
* ログインしているユーザー名が表示されるようになり、本当にログイン出来ているか判別できるようになった。
* ログアウトが可能になった。
* フィルター機能を実装し、絞り込みができるようになった。
* アタックログに記載した最新の情報をダッシュボードで確認できるようになった。
* アタックログの架電結果をプルダウン形式に変更し、フィルターでの検索を容易にした
## できなくなること（ユーザ目線）
* 「無し」
## 動作確認
* 実際にアカウントを作成し、ログインして確認。
* アタックログに2件以上記載し、最新の情報が取得できているか確認。
* ログアウトしてコンソール確認
## その他
* 今回tokenではなく、ローカルストレージを使用して、ログインしているアドレスからユーザー名を特
定しログインしているが、現場ではどのようにしていますか？
## 画面の画像など
<img width="679" alt="スクリーンショット 2024-02-27 22 18 07" src="https://github.com/omegamaster86/calling/assets/116470163/bc54a87f-6148-4644-b1f7-3737d336adfa">
<img width="1275" alt="スクリーンショット 2024-02-27 22 34 19" src="https://github.com/omegamaster86/calling/assets/116470163/10b865f9-4cfa-4f94-804b-f6062be055f9">
<img width="601" alt="スクリーンショット 2024-02-28 23 37 31" src="https://github.com/omegamaster86/calling/assets/116470163/8679812b-492d-4a5e-898e-686f23332bb3">
