### PR TITLE
アタックログで「前」「次」「閉」ボタンの機能を実装

### DIFF
--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -8,7 +8,7 @@ import { FilterIndustryCompany } from '../FilterComponents/FilterCompanyIndustry
 import { FilterSalesman } from '../FilterComponents/FilterSalesman';
 import { FilterNextCallingDay } from '../FilterComponents/FilterNextCallingDay'
 import { useCompanyAndKeyPersonsData } from './useSWRCompanyList';
-import { Company,ExtendedCompany  } from '../../types/interface';
+import { Company,ExtendedCompany, ExtendedCompanyWithKeyPerson } from '../../types/interface';
 import { useRouter } from 'next/router';
 
   export const CompanyList = () => {
@@ -45,8 +45,8 @@ import { useRouter } from 'next/router';
     if (isLoading) return <div>Loading...</div>;
     if (isError) return <div>Error loading data</div>;
 
-    const handleSelectChange = (event) => {
-      setFilterCallingResult(event.target.value);
+    const handleCallingResultChange = (newValue: string) => {
+      setFilterCallingResult(newValue);
     };
     const handleCompanyChange = (companyName: string) => {
       setFilterCompanyName(companyName);
@@ -90,7 +90,7 @@ import { useRouter } from 'next/router';
     <div>
         <div className="flex h-[70px] bg-cyan-400 items-center justify-around">
           <div className='flex'>
-            <FilterCallingResult selectedOption={filterCallingResult} onCallingResultChange={handleSelectChange}/>
+            <FilterCallingResult filterCallingResult={filterCallingResult} onCallingResultChange={handleCallingResultChange}/>
             <FilterCompany filterCompanyName={filterCompanyName} onCompanyChange={handleCompanyChange}/>
             <FilterCompanyNumber filterCompanyNumber={filterCompanyNumber} onCompanyNumberChange={handleInputNumberChange}/>
             <FilterIndustryCompany filterCompanyIndustry={filterCompanyIndustry} onCompanyIndustryChange={handleIndustryChange}/>
@@ -118,7 +118,7 @@ import { useRouter } from 'next/router';
                 </tr>
               </thead>
               <tbody  className='border-solid border-2'>
-                {filteredCompanies.map((company, index) => {
+                {filteredCompanies.map((company: ExtendedCompanyWithKeyPerson, index: number) => {
                    const params = new URLSearchParams({
                     company: company.id.toString(),
                     filteredIds: filteredCompanyIds.join(','),
@@ -130,12 +130,6 @@ import { useRouter } from 'next/router';
                     filterNextCallingDay
                   }).toString();
                   return (
-                    // ダッシュボードからアタックログにクエリ情報を渡す
-                    // クエリに直接filteredCompanyIdsを記載しないURLSearchParamsを使用する
-                    // リダイレクトした際にクエリデータをcompany.keyPerson.nameとかにセットする
-                    // name=田中のデータをアタックログに渡す（クエリで）リダイレクトする際にクエリデータをURLに渡す
-                    // リダイレクトした際にURLSearchParamsを使用してクエリデータをセットする.
-                    // どこに？
                     <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-100'}>
                       <td className='border-2'>{company.address}</td>
                       <td className='border-2'>{company.latestCallResult}</td>

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -6,8 +6,9 @@ import { FilterCompany } from '../FilterComponents/FilterCompany';
 import { FilterCompanyNumber } from '../FilterComponents/FilterCompanyNumber';
 import { FilterIndustryCompany } from '../FilterComponents/FilterCompanyIndustry';
 import { FilterSalesman } from '../FilterComponents/FilterSalesman';
+import { FilterNextCallingDay } from '../FilterComponents/FilterNextCallingDay';
 import { useCompanyAndKeyPersonsData } from './useSWRCompanyList';
-import { Company } from '../../types/interface';
+import { Company,ExtendedCompany  } from '../../types/interface';
 
   export const CompanyList = () => {
     // const [companies, setCompanies] = useState([]);
@@ -16,6 +17,7 @@ import { Company } from '../../types/interface';
     const [filterCompanyNumber, setFilterCompanyNumber] = useState('');
     const [filterCompanyIndustry, setFilterCompanyIndustry] = useState('');
     const [filterCompanySalesman, setFilterCompanySalesman] = useState('');
+    const [filterNextCallingDay, setNextCallingDay ] = useState('');
     const { mergedData, isLoading, isError } = useCompanyAndKeyPersonsData();
     
     if (isLoading) return <div>Loading...</div>;
@@ -36,6 +38,9 @@ import { Company } from '../../types/interface';
     const handleSalesmanChange = (companySalesman: string) => {
       setFilterCompanySalesman(companySalesman);
     };
+    const handleNextCallingDayChange = (NextCallingDay: string) => {
+      setNextCallingDay(NextCallingDay);
+    };
 
     const filteredCompanies = mergedData
     .filter((company: Company) =>
@@ -50,17 +55,14 @@ import { Company } from '../../types/interface';
     )
     .filter((company: Company) =>
       filterCompanySalesman === '' || company.keyPerson.name.toLowerCase().includes(filterCompanySalesman.toLowerCase()) 
+    )
+    .filter((company: ExtendedCompany) =>
+    filterNextCallingDay === '' || company.nextCallDay!.toLowerCase().includes(filterNextCallingDay.toLowerCase()) 
     );
-    // 現在は試しでkeyPersonを表示、品等は営業担当に変更する
+    const filteredCompanyIds = filteredCompanies.map((company: Company) => company.id);
 
-
-    // アタックログから情報を取得
-    // const filteredCallingResult = selectedOption
-    // ? companies.filter(company => attacklog.--- === selectedOption) // 仮にアポイント結果をappointmentResultプロパティと仮定
-    // : companies;
   
     return (
-      // console.log(filteredCompanies),
     <div>
         <div className="flex h-[70px] bg-cyan-400 items-center justify-around">
           <div className='flex'>
@@ -69,6 +71,7 @@ import { Company } from '../../types/interface';
             <FilterCompanyNumber onCompanyNumberChange={handleInputNumberChange}/>
             <FilterIndustryCompany onCompanyIndustryChange={handleIndustryChange}/>
             <FilterSalesman onCompanySalesmanChange={handleSalesmanChange}/>
+            <FilterNextCallingDay onNextCallingDayChange={handleNextCallingDayChange}/>
             <Button colorScheme='blue' mx='5' type="submit" px="90">
               <Link href={'/company-resister'}>企業登録フォームへ</Link>
             </Button>
@@ -101,7 +104,7 @@ import { Company } from '../../types/interface';
                       <td className='border-2'>アポイント{index + 1}</td>
                       <td className='border-2'>担当者 {index + 1}</td>
                       <td className='border-2'>予定日 {index + 1}</td>
-                      <td className='border-2'><Link href={`/attacklog?company=${company.id}`}>{company.company_name}</Link></td>
+                      <td className='border-2'><Link href={`/attacklog?company=${company.id}&filteredIds=${filteredCompanyIds.join(',')}`}>{company.company_name}</Link></td>
                       <td className='border-2'>{company.telephone_number}</td>
                       <td className='border-2'>{companyIndustry}</td>
                       <td className='border-2'>{company.keyPerson? company.keyPerson.name : 'N/A'}</td>

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -135,7 +135,7 @@ import { useRouter } from 'next/router';
                       <td className='border-2'>{company.latestCallResult}</td>
                       <td className='border-2'>{company.latestSalesman}</td>
                       <td className='border-2'>{company.nextCallDay}</td>
-                      <td className='border-2'><Link href={`/attacklog?${params}`}>{company.company_name}</Link></td>
+                      <td className='border-2 text-indigo-600 hover:underline underline-offset-2'><Link href={`/attacklog?${params}`}>{company.company_name}</Link></td>
                       <td className='border-2'>{company.telephone_number}</td>
                       <td className='border-2'>{company.industry}</td>
                       <td className='border-2'>{company.keyPerson? company.keyPerson.name : ''}</td>

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -96,7 +96,7 @@ import { useRouter } from 'next/router';
             <FilterIndustryCompany filterCompanyIndustry={filterCompanyIndustry} onCompanyIndustryChange={handleIndustryChange}/>
             <FilterSalesman filterSalesman={filterSalesman} onCompanySalesmanChange={handleSalesmanChange}/>
             <FilterNextCallingDay filterNextCallingDay={filterNextCallingDay} onNextCallingDayChange={handleNextCallingDayChange}/>
-            <Button colorScheme='blue' mx='5' type="submit" px="90">
+            <Button colorScheme='blue' mx='5' type="submit" px="3">
               <Link href={'/company-resister'}>企業登録フォームへ</Link>
             </Button>
           </div>

--- a/front/components/FilterComponents/FilterCallingResult.tsx
+++ b/front/components/FilterComponents/FilterCallingResult.tsx
@@ -20,7 +20,7 @@ export const FilterCallingResult: React.FC<FilterCallingResult> = ({ filterCalli
   };
 
   return (
-        <Select placeholder='架電結果' bg='Cyan 50' ml='5' value={callingResult} onChange={handleCallingResultChange}>
+        <Select placeholder='架電結果' bg='Cyan 50' ml='5' w='110' value={callingResult} onChange={handleCallingResultChange}>
             <option value='アポイント'>アポイント</option>
             <option value='コンタクト'>コンタクト</option>
             <option value='資料送付'>資料送付</option>

--- a/front/components/FilterComponents/FilterCallingResult.tsx
+++ b/front/components/FilterComponents/FilterCallingResult.tsx
@@ -2,18 +2,25 @@ import { Select } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
 
 interface FilterCallingResult {
-    selectedOption: string;
-    onCallingResultChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    filterCallingResult: string;
+    onCallingResultChange: (value: string) => void
   }
 
-export const FilterCallingResult: React.FC<FilterCallingResult> = ({ selectedOption, onCallingResultChange }) => {
-  const [filterOption, setFilterOption] = useState(selectedOption || '');
+export const FilterCallingResult: React.FC<FilterCallingResult> = ({ filterCallingResult, onCallingResultChange }) => {
+  const [callingResult, setCallingResult] = useState(filterCallingResult || '');
 
   useEffect(() => {
-    setFilterOption(selectedOption || '');
-  }, [selectedOption]);
+    setCallingResult(filterCallingResult || '');
+  }, [filterCallingResult]);
+
+  const handleCallingResultChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = event.target.value;
+    setCallingResult(selectedValue);
+    onCallingResultChange(selectedValue);
+  };
+
   return (
-        <Select placeholder='架電結果' bg='Cyan 50' ml='5' value={filterOption} onChange={onCallingResultChange}>
+        <Select placeholder='架電結果' bg='Cyan 50' ml='5' value={callingResult} onChange={handleCallingResultChange}>
             <option value='アポイント'>アポイント</option>
             <option value='コンタクト'>コンタクト</option>
             <option value='資料送付'>資料送付</option>

--- a/front/components/FilterComponents/FilterCallingResult.tsx
+++ b/front/components/FilterComponents/FilterCallingResult.tsx
@@ -1,13 +1,19 @@
 import { Select } from '@chakra-ui/react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface FilterCallingResult {
+    selectedOption: string;
     onCallingResultChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   }
 
-export const FilterCallingResult: React.FC<FilterCallingResult> = ({ onCallingResultChange }) => {
+export const FilterCallingResult: React.FC<FilterCallingResult> = ({ selectedOption, onCallingResultChange }) => {
+  const [filterOption, setFilterOption] = useState(selectedOption || '');
+
+  useEffect(() => {
+    setFilterOption(selectedOption || '');
+  }, [selectedOption]);
   return (
-        <Select placeholder='架電結果' bg='Cyan 50' ml='5' w={130} onChange={onCallingResultChange}>
+        <Select placeholder='架電結果' bg='Cyan 50' ml='5' value={filterOption} onChange={onCallingResultChange}>
             <option value='アポイント'>アポイント</option>
             <option value='コンタクト'>コンタクト</option>
             <option value='資料送付'>資料送付</option>

--- a/front/components/FilterComponents/FilterCompany.tsx
+++ b/front/components/FilterComponents/FilterCompany.tsx
@@ -1,13 +1,17 @@
 import { Stack, Input } from '@chakra-ui/react';
-import React from 'react';
-import { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface FilterCompanyProps {
+    filterCompanyName: string;
     onCompanyChange: (companyName: string) => void;
   }
   
-  export const FilterCompany: React.FC<FilterCompanyProps> = ({ onCompanyChange }) => {
-    const [companyName, setCompanyName] = useState('');
+  export const FilterCompany: React.FC<FilterCompanyProps> = ({ filterCompanyName, onCompanyChange }) => {
+    const [companyName, setCompanyName] = useState(filterCompanyName ||'');
+
+    useEffect(() => {
+      setCompanyName(filterCompanyName || '');
+    }, [filterCompanyName]);
   
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setCompanyName(event.target.value);

--- a/front/components/FilterComponents/FilterCompanyIndustry.tsx
+++ b/front/components/FilterComponents/FilterCompanyIndustry.tsx
@@ -1,13 +1,17 @@
 import { Stack, Input } from '@chakra-ui/react';
-import React from 'react';
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface FilterCompanyProps {
+    filterCompanyIndustry: string;
     onCompanyIndustryChange: (companyIndustry: string) => void;
   }
   
-  export const FilterIndustryCompany: React.FC<FilterCompanyProps> = ({ onCompanyIndustryChange }) => {
-    const [companyIndustry, setCompanyIndustry] = useState('');
+  export const FilterIndustryCompany: React.FC<FilterCompanyProps> = ({ filterCompanyIndustry, onCompanyIndustryChange }) => {
+    const [companyIndustry, setCompanyIndustry] = useState(filterCompanyIndustry ||'');
+
+    useEffect(() => {
+      setCompanyIndustry(filterCompanyIndustry || '');
+    }, [filterCompanyIndustry]);
   
     const handleIndustryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setCompanyIndustry(event.target.value);

--- a/front/components/FilterComponents/FilterCompanyNumber.tsx
+++ b/front/components/FilterComponents/FilterCompanyNumber.tsx
@@ -1,13 +1,17 @@
 import { Stack, Input } from '@chakra-ui/react';
-import React from 'react';
-import { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface FilterCompanyProps {
+    filterCompanyNumber: string;
     onCompanyNumberChange: (companyNumber: string) => void;
   }
   
-  export const FilterCompanyNumber: React.FC<FilterCompanyProps> = ({ onCompanyNumberChange }) => {
-    const [companyNumber, setCompanyNumber] = useState('');
+  export const FilterCompanyNumber: React.FC<FilterCompanyProps> = ({ filterCompanyNumber, onCompanyNumberChange }) => {
+    const [companyNumber, setCompanyNumber] = useState(filterCompanyNumber ||'');
+
+    useEffect(() => {
+      setCompanyNumber(filterCompanyNumber || '');
+    }, [filterCompanyNumber]);
   
     const handleInputNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setCompanyNumber(event.target.value);

--- a/front/components/FilterComponents/FilterNextCallingDay.tsx
+++ b/front/components/FilterComponents/FilterNextCallingDay.tsx
@@ -1,0 +1,29 @@
+import { Stack, Input } from '@chakra-ui/react';
+import React from 'react';
+import { useState } from 'react';
+
+interface FilterCompanyProps {
+    onNextCallingDayChange: (companyIndustry: string) => void;
+  }
+  
+  export const FilterNextCallingDay: React.FC<FilterCompanyProps> = ({ onNextCallingDayChange }) => {
+    const [NextCallingDay, setNextCallingDay] = useState('');
+  
+    const handleNextCallingDayChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setNextCallingDay(event.target.value);
+      onNextCallingDayChange(event.target.value);
+    };
+
+  return (
+    <Stack ml='5'>
+      <Input
+        placeholder='次回架電日'
+        size='md'
+        bg='Cyan 50'
+        w='120px'
+        value={NextCallingDay}
+        onChange={handleNextCallingDayChange}
+      />
+    </Stack>
+  );
+}

--- a/front/components/FilterComponents/FilterNextCallingDay.tsx
+++ b/front/components/FilterComponents/FilterNextCallingDay.tsx
@@ -1,13 +1,17 @@
 import { Stack, Input } from '@chakra-ui/react';
-import React from 'react';
-import { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface FilterCompanyProps {
+    filterNextCallingDay: string;
     onNextCallingDayChange: (companyIndustry: string) => void;
   }
   
-  export const FilterNextCallingDay: React.FC<FilterCompanyProps> = ({ onNextCallingDayChange }) => {
-    const [NextCallingDay, setNextCallingDay] = useState('');
+  export const FilterNextCallingDay: React.FC<FilterCompanyProps> = ({ filterNextCallingDay, onNextCallingDayChange }) => {
+    const [NextCallingDay, setNextCallingDay] = useState(filterNextCallingDay ||'');
+
+    useEffect(() => {
+      setNextCallingDay(filterNextCallingDay || '');
+    }, [filterNextCallingDay]);
   
     const handleNextCallingDayChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setNextCallingDay(event.target.value);

--- a/front/components/FilterComponents/FilterSalesman.tsx
+++ b/front/components/FilterComponents/FilterSalesman.tsx
@@ -1,18 +1,22 @@
 import { Stack, Input } from '@chakra-ui/react';
-import React from 'react';
-import { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface FilterCompanyProps {
+    filterSalesman: string;
     onCompanySalesmanChange: (companyIndustry: string) => void;
   }
   
-  export const FilterSalesman: React.FC<FilterCompanyProps> = ({ onCompanySalesmanChange }) => {
-    const [companySalesman, setCompanySalesman] = useState('');
-  
-    const handleSalesmanChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      setCompanySalesman(event.target.value);
-      onCompanySalesmanChange(event.target.value);
-    };
+export const FilterSalesman: React.FC<FilterCompanyProps> = ({ filterSalesman, onCompanySalesmanChange }) => {
+  const [companySalesman, setCompanySalesman] = useState(filterSalesman || '');
+
+  useEffect(() => {
+    setCompanySalesman(filterSalesman || '');
+  }, [filterSalesman]);
+
+  const handleSalesmanChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCompanySalesman(event.target.value);
+    onCompanySalesmanChange(event.target.value);
+  };
 
   return (
     <Stack ml='5'>

--- a/front/pages/attacklog.tsx
+++ b/front/pages/attacklog.tsx
@@ -1,20 +1,61 @@
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import { Company } from '../types/interface';
 import { AttackLogInfo } from "../components/AttackLog/AttackLogInfo";
 import { AttackLogCallHistory } from "../components/AttackLog/AttackLogCallHistory/AttackLogCallHistory";
 import { ArrowLeftIcon, ArrowRightIcon, CloseIcon } from '@chakra-ui/icons';
 
+const fetcher = async (url: string) => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error('An error occurred while fetching the data.');
+    }
+    return response.json();
+};
 
 export default function AttackLog(){
+    const router = useRouter();
+    const { company } = router.query;
+    const { data: companiesData, error: companiesError } = useSWR(`${process.env.NEXT_PUBLIC_API_URL}/companies`, fetcher);
+    const companyIds = companiesData?.map((company: Company) => company.id) || [];
+
+    const goToNextCompany = () => {
+      // companyがundefinedまたはstring[]型の場合の処理
+      const companyIdString = typeof company === 'string' ? company : Array.isArray(company) ? company[0] : '0';
+      // 現在のcompanyIDを数値に変換
+      const currentId = parseInt(companyIdString, 10);
+      // companyIdsの中で現在のIDの次のIDを見つける
+      const currentIndex = companyIds.indexOf(currentId);
+      const nextIdIndex = currentIndex + 1 === companyIds.length ? 0 : currentIndex + 1;
+
+      const nextId = companyIds[nextIdIndex];
+      router.push(`/attacklog?company=${nextId}`);
+    };
+
+    const goToPrevCompany = () => {
+      const companyIdString = typeof company === 'string' ? company : Array.isArray(company) ? company[0] : '0';
+      const currentId = parseInt(companyIdString, 10);
+
+      const currentIndex = companyIds.indexOf(currentId);
+      const prevIdIndex = currentIndex - 1 < 0 ? companyIds.length - 1 : currentIndex - 1;
+  
+      const prevId = companyIds[prevIdIndex];
+      router.push(`/attacklog?company=${prevId}`);
+    };
+
+    if (companiesError) return <div>データの取得に失敗しました。</div>;
+    if (!companiesData) return <div>ローディング中...</div>;
 
     return(
         <div className=" pt-8">
             <div className="border-b-2 pb-8 flex items-center justify-around">
                 <div className="font-extrabold pl-7">アタックログ</div>
                 <div className="flex ">
-                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold">
+                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold" onClick={goToPrevCompany}>
                         <ArrowLeftIcon color="white.500"/>
-                        <div className="pl-3">前</div>
+                        <div className="pl-3" >前</div>
                     </div>
-                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold">
+                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold" onClick={goToNextCompany}>
                         <div className="pr-3">次</div>
                         <ArrowRightIcon color="white.500"/>
                     </div>

--- a/front/pages/attacklog.tsx
+++ b/front/pages/attacklog.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router';
+import { useRouter, NextRouter } from 'next/router';
 import useSWR from 'swr';
 import { AttackLogInfo } from "../components/AttackLog/AttackLogInfo";
 import { AttackLogCallHistory } from "../components/AttackLog/AttackLogCallHistory/AttackLogCallHistory";
@@ -11,6 +11,15 @@ const fetcher = async (url: string) => {
     }
     return response.json();
 };
+
+const createQueryParams = (router: NextRouter) => new URLSearchParams({
+  filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
+  filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
+  filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
+  filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
+  filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
+  filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
+}).toString();
 
 export default function AttackLog(){
     const router = useRouter();
@@ -29,16 +38,9 @@ export default function AttackLog(){
         // 配列のループ処理
         const nextIdIndex = currentIndex + 1 === filteredCompanyIds.length ? 0 : currentIndex + 1;
         const nextId = filteredCompanyIds[nextIdIndex];
-        const queryParams = new URLSearchParams({
-          filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
-          filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
-          filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
-          filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
-          filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
-          filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
-        }).toString();
+        const queryParams = createQueryParams(router);
     
-        router.push(`/attacklog?company=${nextId}&filteredIds=${filteredIds}?${queryParams}`);
+        router.push(`/attacklog?company=${nextId}&filteredIds=${filteredIds}&${queryParams}`);
       }
     };
 
@@ -48,32 +50,15 @@ export default function AttackLog(){
         const currentIndex = filteredCompanyIds.indexOf(currentId);
         const prevIdIndex = currentIndex - 1 < 0 ? filteredCompanyIds.length - 1 : currentIndex - 1;
         const prevId = filteredCompanyIds[prevIdIndex];
-        const queryParams = new URLSearchParams({
-          filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
-          filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
-          filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
-          filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
-          filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
-          filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
-        }).toString();
+        const queryParams = createQueryParams(router);
     
-        router.push(`/attacklog?company=${prevId}&filteredIds=${filteredIds}?${queryParams}`);
+        router.push(`/attacklog?company=${prevId}&filteredIds=${filteredIds}&${queryParams}`);
       }
     };
     // 会社IDとフィルター条件を保持するクエリパラメーターを詳細ページに持ってくる、リダイレクト画面に戻る（一般的）
     const closeAttackLog = () => {
-      
-      // URLSearchParamsオブジェクトを作成
-      const queryParams = new URLSearchParams({
-        filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
-        filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
-        filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
-        filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
-        filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
-        filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
-      }).toString();
-
-      router.push(`/dashbord?${queryParams}`);
+      const queryParams = createQueryParams(router);
+      router.push(`/dashboard?${queryParams}`);
   };
 
     if (companiesError) return <div>データの取得に失敗しました。</div>;

--- a/front/pages/attacklog.tsx
+++ b/front/pages/attacklog.tsx
@@ -69,15 +69,15 @@ export default function AttackLog(){
             <div className="border-b-2 pb-8 flex items-center justify-around">
                 <div className="font-extrabold pl-7">アタックログ</div>
                 <div className="flex ">
-                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold" onClick={goToPrevCompany}>
+                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold  hover:opacity-50 hover:cursor-pointer" onClick={goToPrevCompany}>
                         <ArrowLeftIcon color="white.500"/>
                         <div className="pl-3" >前</div>
                     </div>
-                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold" onClick={goToNextCompany}>
+                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold  hover:opacity-50 hover:cursor-pointer" onClick={goToNextCompany}>
                         <div className="pr-3">次</div>
                         <ArrowRightIcon color="white.500"/>
                     </div>
-                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold" onClick={closeAttackLog}>
+                    <div className=" bg-emerald-500 w-24 flex items-center rounded-md py-2 px-5 mx-2 text-white font-semibold  hover:opacity-50 hover:cursor-pointer" onClick={closeAttackLog}>
                         <CloseIcon color="white.500"/>
                         <div className="pl-3">閉</div>
                     </div>

--- a/front/pages/attacklog.tsx
+++ b/front/pages/attacklog.tsx
@@ -29,9 +29,16 @@ export default function AttackLog(){
         // 配列のループ処理
         const nextIdIndex = currentIndex + 1 === filteredCompanyIds.length ? 0 : currentIndex + 1;
         const nextId = filteredCompanyIds[nextIdIndex];
-        router.push(`/attacklog?company=${nextId}&filteredIds=${filteredIds}`);
-      } else {
-        router.push(`/attacklog?company=${filteredCompanyIds[0]}&filteredIds=${filteredIds}`);
+        const queryParams = new URLSearchParams({
+          filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
+          filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
+          filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
+          filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
+          filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
+          filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
+        }).toString();
+    
+        router.push(`/attacklog?company=${nextId}&filteredIds=${filteredIds}?${queryParams}`);
       }
     };
 
@@ -41,15 +48,33 @@ export default function AttackLog(){
         const currentIndex = filteredCompanyIds.indexOf(currentId);
         const prevIdIndex = currentIndex - 1 < 0 ? filteredCompanyIds.length - 1 : currentIndex - 1;
         const prevId = filteredCompanyIds[prevIdIndex];
-        router.push(`/attacklog?company=${prevId}&filteredIds=${filteredIds}`);
-      } else {
-        router.push(`/attacklog?company=${filteredCompanyIds[filteredCompanyIds.length - 1]}&filteredIds=${filteredIds}`);
+        const queryParams = new URLSearchParams({
+          filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
+          filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
+          filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
+          filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
+          filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
+          filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
+        }).toString();
+    
+        router.push(`/attacklog?company=${prevId}&filteredIds=${filteredIds}?${queryParams}`);
       }
     };
-
+    // 会社IDとフィルター条件を保持するクエリパラメーターを詳細ページに持ってくる、リダイレクト画面に戻る（一般的）
     const closeAttackLog = () => {
-        router.push(`/dashboard`);
-    };
+      
+      // URLSearchParamsオブジェクトを作成
+      const queryParams = new URLSearchParams({
+        filterCallingResult: Array.isArray(router.query.filterCallingResult) ? router.query.filterCallingResult[0] : router.query.filterCallingResult || '',
+        filterCompanyName: Array.isArray(router.query.filterCompanyName) ? router.query.filterCompanyName[0] : router.query.filterCompanyName || '',
+        filterCompanyNumber: Array.isArray(router.query.filterCompanyNumber) ? router.query.filterCompanyNumber[0] : router.query.filterCompanyNumber || '',
+        filterCompanyIndustry: Array.isArray(router.query.filterCompanyIndustry) ? router.query.filterCompanyIndustry[0] : router.query.filterCompanyIndustry || '',
+        filterSalesman: Array.isArray(router.query.filterSalesman) ? router.query.filterSalesman[0] : router.query.filterSalesman || '',
+        filterNextCallingDay: Array.isArray(router.query.filterNextCallingDay) ? router.query.filterNextCallingDay[0] : router.query.filterNextCallingDay || '',
+      }).toString();
+
+      router.push(`/dashbord?${queryParams}`);
+  };
 
     if (companiesError) return <div>データの取得に失敗しました。</div>;
     if (!companiesData) return <div>ローディング中...</div>;

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -55,7 +55,7 @@ export interface AttackLogFormState {
 }
 
 export interface Company {
-  id?: number;
+  id: number;
   company_name: string;
   industry: string;
   address: string;

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -15,15 +15,15 @@ export interface FormValues {
 
 // CompanyRegister.tsxで使用
 export interface CompanyResisterFormState {
-  companyName: string | null;
-  industry: string | null;
-  address: string | null;
-  telephoneNumber: string | null;
-  companyWebsite: string | null;
-  department: string | null;
-  post: string | null;
-  name: string | null;
-  email: string | null;
+	companyName: string | null;
+	industry: string | null;
+	address: string | null;
+	telephoneNumber: string | null;
+	companyWebsite: string | null;
+	department: string | null;
+	post: string | null;
+	name: string | null;
+	email: string | null;
 }
 
 // CompanyRegister.tsxで使用
@@ -82,3 +82,9 @@ export interface AttackLog {
 	next_call_day: string;
 	salesman: string;
 }
+
+export interface ExtendedCompany extends Company {
+	latestSalesman?: string; // 最新の営業担当者名
+	latestCallResult?: string; // 最新の架電結果
+	nextCallDay?: string; // 次回予定日
+  }

--- a/front/types/interface.ts
+++ b/front/types/interface.ts
@@ -74,15 +74,15 @@ export interface KeyPerson {
 }
 
 export interface AttackLog {
-  company_id?: bigint;
-  calling_day: string;
-  calling_start: string;
-  call_result: string;
-  call_content: string;
-  next_call_day: string;
-  salesman: string;
-  created_at: string;
-  updated_at: string;
+	company_id?: bigint;
+	calling_day: string;
+	calling_start: string;
+	call_result: string;
+	call_content: string;
+	next_call_day: string;
+	salesman: string;
+	created_at: string;
+	updated_at: string;
 }
 
 export interface ExtendedCompany extends Company {


### PR DESCRIPTION
## やったこと
* アタックログで「前」「次」「閉」ボタンの機能を実装
## やらないこと
* 「無し」
## 課題
* 「閉」ボタンを押した際に、ダッシュボードに遷移するように実装。
しかしやりたいこととしては「閉」ボタンを押した際に、フィルターした情報を保持したい。
理想：フィルター後、会社名をクリックしアタックログへ遷移、「閉」を押すとフィルター後値を保持した状態に遷移。
現状：フィルター後、会社名をクリックしアタックログへ遷移、「閉」を押すとフィルターの値がリセットされている
## できるようになること（ユーザ目線）
* アタックログ上でフィルター後の会社情報を取得し、遷移可能になる。
## できなくなること（ユーザ目線）
* 「無し」
## 動作確認
* 実際にフィルターをかけ動作確認した。
## 画面の画像など
動画をSlackで共有します。