### PR TITLE
useEffectやuseStateで不要にレンダリングされている箇所をuseMemoで対応

### DIFF
--- a/api/app/controllers/attack_logs_controller.rb
+++ b/api/app/controllers/attack_logs_controller.rb
@@ -19,8 +19,8 @@ class AttackLogsController < ApplicationController
         # 既存のcompanyに対する更新処理があればここに記述
         company.update!(company_params)
 
-        # key_personの更新が必要な場合は、companyに紐づくkey_personをメールアドレスで検索し、更新する
-        key_person = company.key_people.find_by!(email: params[:key_person][:email])
+        # key_personの更新が必要な場合は、companyに紐づくkey_personをidで検索し、更新する
+        key_person = company.key_people.first
         key_person.update!(key_person_params)
 
         attack_log = company.attack_logs.find_or_initialize_by(id: params[:attack_log][:id])

--- a/api/app/models/key_person.rb
+++ b/api/app/models/key_person.rb
@@ -1,7 +1,5 @@
 class KeyPerson < ApplicationRecord
     belongs_to :company
-    before_save { self.email = email.downcase }
 
     VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-    validates :email, {presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }}
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   post '/login', to: 'authentication#login'
   get '/dashboard', to: 'dashboards#index'
 
-  resources :companies, only: [:index, :create]
+  resources :companies, only: [:index]
   post '/companies', to: 'companies#create_with_key_person'
 
   resources :key_persons, only: [:index, :create]

--- a/front/components/AttackLog/AttackLogCallResult.tsx
+++ b/front/components/AttackLog/AttackLogCallResult.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import type { FC, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import { FilterCallingResult } from "../FilterComponents/FilterCallingResult";
@@ -62,7 +62,6 @@ export const AttackLogCallResult: FC<AttackLogCallResultProps> = ({
 	onInputChange,
 	errors,
 }) => {
-	// const [companies, setCompanies] = useState([]);
 	const router = useRouter();
 	const company = router.query.company as string | string[] | undefined;
 	const [callingStart, setCallingStart] = useState("");
@@ -83,31 +82,34 @@ export const AttackLogCallResult: FC<AttackLogCallResultProps> = ({
 	if (companiesError || AttackLogsError)
 		return <div>データの読み込みに失敗しました。</div>;
 
-	useEffect(() => {
+	const selectedCompany = useMemo(() => {
 		if (!companiesData || !AttackLogsData) return;
+
 		const mergedData = companiesData.map((company: Company) => ({
 			...company,
 			AttackLog: AttackLogsData.find(
 				(at: AttackLog) => at.company_id?.toString() === company.id.toString(),
 			),
 		}));
-		const selectedCompany = mergedData.find(
-			(comp: Company) => comp.id.toString() === company,
-		); // companyクエリと一致するIDを持つ会社を探す
-		if (selectedCompany) {
-			setCallingStart(selectedCompany.calling_start);
-			setCallResult(selectedCompany.call_result);
-			setNextCallDay(selectedCompany.next_call_day);
-			setSalesman(selectedCompany.salesman);
-			setCallContent(selectedCompany.call_content);
 
-			onInputChange("callingStart", selectedCompany.calling_start);
-			onInputChange("callResult", selectedCompany.call_result);
-			onInputChange("nextCallDay", selectedCompany.next_call_day);
-			onInputChange("salesman", selectedCompany.salesman);
-			onInputChange("callContent", selectedCompany.call_content);
-		}
-	}, [onInputChange, companiesData, AttackLogsData, company]);
+		return mergedData.find((comp: Company) => comp.id.toString() === company);
+	}, [companiesData, AttackLogsData, company]);
+
+	useEffect(() => {
+		if (!selectedCompany) return;
+
+		setCallingStart(selectedCompany.calling_start || "");
+		setCallResult(selectedCompany.call_result || "");
+		setNextCallDay(selectedCompany.next_call_day || "");
+		setSalesman(selectedCompany.salesman || "");
+		setCallContent(selectedCompany.call_content || "");
+
+		onInputChange("callingStart", selectedCompany.calling_start || "");
+		onInputChange("callResult", selectedCompany.call_result || "");
+		onInputChange("nextCallDay", selectedCompany.next_call_day || "");
+		onInputChange("salesman", selectedCompany.salesman || "");
+		onInputChange("callContent", selectedCompany.call_content || "");
+	}, [selectedCompany, onInputChange]);
 
 	const handleCallingStartInputChange = (e: ChangeEvent<HTMLInputElement>) => {
 		setCallingStart(e.target.value);

--- a/front/components/AttackLog/AttackLogInfo.tsx
+++ b/front/components/AttackLog/AttackLogInfo.tsx
@@ -1,5 +1,5 @@
 import * as yup from "yup";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import axios from "axios";
 import { useRouter } from "next/router";
 import type { FC } from "react";
@@ -17,6 +17,8 @@ export const AttackLogInfo: FC<AttackLogProps> = () => {
 	const router = useRouter();
 	const companyId = router.query.company;
 	const [isPostSuccess, setIsPostSuccess] = useState(false);
+	const [isPostError, setIsPostError] = useState(false);
+	const [showAlert, setShowAlert] = useState(false);
 	const [formErrors, setFormErrors] = useState<{ [key: string]: string }>({});
 	const formSchema = yup.object().shape({
 		companyName: yup
@@ -105,8 +107,11 @@ export const AttackLogInfo: FC<AttackLogProps> = () => {
 
 			if (response.status === 201) {
 				setIsPostSuccess(true);
-				// TODO: リダイレクトする方法で検討
+				setIsPostError(false);
 				router.reload();
+			} else {
+				setIsPostError(true);
+				setIsPostSuccess(false);
 			}
 		} catch (error) {
 			if (error instanceof yup.ValidationError) {
@@ -127,6 +132,16 @@ export const AttackLogInfo: FC<AttackLogProps> = () => {
 		}
 	};
 
+	useEffect(() => {
+		if (isPostSuccess || isPostError) {
+			setShowAlert(true);
+			const timer = setTimeout(() => {
+				setShowAlert(false);
+			}, 3000);
+			return () => clearTimeout(timer);
+		}
+	}, [isPostSuccess, isPostError]);
+
 	return (
 		<div className="mt-5 mx-auto">
 			<form onSubmit={handleSubmit}>
@@ -143,11 +158,19 @@ export const AttackLogInfo: FC<AttackLogProps> = () => {
 					errors={formErrors}
 				/>
 				<div className=" pl-24 w-64 pb-4">
-					{isPostSuccess && (
+					{isPostSuccess && showAlert && (
 						<Stack spacing={3}>
 							<Alert status="success">
 								<AlertIcon />
 								登録完了!
+							</Alert>
+						</Stack>
+					)}
+					{isPostError && showAlert && (
+						<Stack spacing={3}>
+							<Alert status="error">
+								<AlertIcon />
+								登録失敗。
 							</Alert>
 						</Stack>
 					)}

--- a/front/components/AttackLog/AttackLogKeyPerson.tsx
+++ b/front/components/AttackLog/AttackLogKeyPerson.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import type { FC, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import type { Company, KeyPerson } from "@/types/interface";
@@ -71,33 +71,37 @@ export const AttackLogKeyPerson: FC<AttackLogKeyPersonProps> = ({
 	if (companiesError || keyPersonsError)
 		return <div>データの読み込みに失敗しました。</div>;
 
-	useEffect(() => {
-		if (!companiesData || !keyPersonsData) return;
-		const mergedData = companiesData.map((company: Company) => ({
-			...company,
-			keyPerson: keyPersonsData.find(
-				(kp: KeyPerson) => kp.company_id?.toString() === company.id.toString(),
-			),
-		}));
-		const selectedCompany = mergedData.find(
-			(comp: Company) => comp.id.toString() === company,
-		); // companyクエリと一致するIDを持つ会社を探す
-		if (selectedCompany) {
-			setDepartment(selectedCompany.keyPerson.department); // 見つかったらその名前を設定
-			setPost(selectedCompany.keyPerson.post);
-			setName(selectedCompany.keyPerson.name);
-			setTelephoneNumber(selectedCompany.keyPerson.telephone_number);
-			setEmail(selectedCompany.keyPerson.email);
-			setNote(selectedCompany.keyPerson.note);
+		const selectedCompany = useMemo(() => {
+			if (!companiesData || !keyPersonsData) return null;
+	
+			const mergedData = companiesData.map((company: Company) => ({
+				...company,
+				keyPerson: keyPersonsData.find(
+					(kp: KeyPerson) => kp.company_id?.toString() === company.id.toString(),
+				),
+			}));
+	
+			return mergedData.find((comp: Company) => comp.id.toString() === company);
+		}, [companiesData, keyPersonsData, company]);
 
-			onInputChange("department", selectedCompany.keyPerson.department); // 見つかったらその名前を設定
-			onInputChange("post", selectedCompany.keyPerson.post);
-			onInputChange("name", selectedCompany.keyPerson.name);
-			onInputChange("number", selectedCompany.keyPerson.telephone_number);
-			onInputChange("email", selectedCompany.keyPerson.email);
-			onInputChange("note", selectedCompany.keyPerson.note);
-		}
-	}, [onInputChange, companiesData, keyPersonsData, company]);
+		useEffect(() => {
+			if (!selectedCompany) return;
+	
+			setDepartment(selectedCompany.keyPerson.department || ""); // 見つかったらその名前を設定
+			setPost(selectedCompany.keyPerson.post || "");
+			setName(selectedCompany.keyPerson.name || "");
+			setTelephoneNumber(selectedCompany.keyPerson.telephone_number || "");
+			setEmail(selectedCompany.keyPerson.email || "");
+			setNote(selectedCompany.keyPerson.note || "");
+	
+			// onInputChangeコールバックを利用して親コンポーネントに変更を伝える
+			onInputChange("department", selectedCompany.keyPerson.department || ""); // 見つかったらその名前を設定
+			onInputChange("post", selectedCompany.keyPerson.post || "");
+			onInputChange("name", selectedCompany.keyPerson.name || "");
+			onInputChange("number", selectedCompany.keyPerson.telephone_number || "");
+			onInputChange("email", selectedCompany.keyPerson.email || "");
+			onInputChange("note", selectedCompany.keyPerson.note || "");
+		}, [selectedCompany, onInputChange]);
 
 	const handleDepartmentInputChange = (e: ChangeEvent<HTMLInputElement>) => {
 		setDepartment(e.target.value);

--- a/front/components/CompanyList/CompanyList.tsx
+++ b/front/components/CompanyList/CompanyList.tsx
@@ -168,7 +168,6 @@ export const CompanyList = () => {
 			<div
 				className="flex justify-around"
 				style={{
-					height: "800px",
 					width: "100%",
 					overflowX: "auto",
 					overflowY: "auto",


### PR DESCRIPTION
## やったこと
* useEffectやuseStateで不要にレンダリングされている箇所をuseMemoで対応
## やらないこと
* 「無し」
## 課題
* emailと一致するキーパーソンIDを探しているような挙動をしていますが、どうしてそのような挙動をしているか不明。
下記が該当箇所のコード
 `    begin
      ActiveRecord::Base.transaction do
        # URLからcompanyパラメータを取得
        company_id = params[:company_id]
        company = Company.find(company_id)

        # 既存のcompanyに対する更新処理があればここに記述
        company.update!(company_params)

        key_person = company.key_people.first
        key_person.update!(key_person_params)

        attack_log = company.attack_logs.find_or_initialize_by(id: params[:attack_log][:id])
        attack_log.update!(attack_log_params)

        render json: { success: true, attack_log_id: attack_log.id }, status: :created
      end`
ログの内容
<img width="1365" alt="スクリーンショット 2024-03-27 15 05 33" src="https://github.com/omegamaster86/calling/assets/116470163/c8226c4f-c52d-4c8c-9778-52a0af50f4d3">

## できるようになること（ユーザ目線）
* 「無し」
## できなくなること（ユーザ目線）
* 「無し」
## 動作確認
* 実際に動かし、他の企業のアタックログに遷移した際にレンダリングが行われないことを確認。